### PR TITLE
Fix link to tensap doc/gh

### DIFF
--- a/software.html
+++ b/software.html
@@ -111,7 +111,7 @@ License URL: http://creativecommons.org/licenses/by/3.0/
 <a href="https://anthony-nouy.github.io/ApproximationToolbox/">ApproximationToolbox</a></font>
 </p>
 An object-oriented MATLAB toolbox for the approximation of functions and tensors.<br />
-<a href="https://anthony-nouy.github.io/ApproximationToolbox/">GitHub page.</a>
+<a href="https://github.com/anthony-nouy/ApproximationToolbox/">GitHub page.</a>
 </li>
 </ul>
 <br>
@@ -120,7 +120,8 @@ An object-oriented MATLAB toolbox for the approximation of functions and tensors
 <a href="https://anthony-nouy.github.io/tensap/">tensap</a></font>
 </p>
 A Python package for the approximation of functions and tensors.<br />
-<a href="https://anthony-nouy.github.io/tensap/">GitHub page.</a>
+<a href="https://anthony-nouy.github.io/sphinx/tensap/master">Documentation</a><br/>
+<a href="https://github.com/anthony-nouy/tensap/">GitHub page.</a>
 </li>
 </ul>
 <div class="about-grids">


### PR DESCRIPTION
This PR adds a link to the tensap sphinx documentation from https://anthony-nouy.github.io/software.html
Maybe it would be best to add it into the https://anthony-nouy.github.io/tensap/ subpage but I could not find where to edit it.
It also fixes the github project pages links

